### PR TITLE
Updated RES generation script to include cases with inputs but no outputs

### DIFF
--- a/tools/res_generator/osemosys_RES.py
+++ b/tools/res_generator/osemosys_RES.py
@@ -23,9 +23,9 @@ def main(data_infile, out_file):
 		for line in f:
 			if line.startswith('set YEAR'):
 				start_year = line.split(' ')[3]
-			if line.startswith('set COMMODITY'): # Extracts list of COMMODITIES from data file. Some models use FUEL instead. 
+			if line.startswith('set COMMODITY'): # Extracts list of COMMODITIES from data file. Some models use FUEL instead.
 				fuel_list = line.split(' ')[3:-1]
-			if line.startswith('set FUEL'): # Extracts list of FUELS from data file. Some models use COMMODITIES instead. 
+			if line.startswith('set FUEL'): # Extracts list of FUELS from data file. Some models use COMMODITIES instead.
 				fuel_list = line.split(' ')[3:-1]
 			if line.startswith('set TECHNOLOGY'):
 				tech_list = line.split(' ')[3:-1]
@@ -33,10 +33,10 @@ def main(data_infile, out_file):
 				storage_list = line.split(' ')[3:-1]
 			if line.startswith('set MODE_OF_OPERATION'):
 				mode_list = line.split(' ')[3:-1]
-			
+
 			if line.startswith(";"):
-					parsing = False   
-			
+					parsing = False
+
 			if parsing:
 				if line.startswith('['):
 					fuel = line.split(',')[2]
@@ -47,15 +47,15 @@ def main(data_infile, out_file):
 				else:
 					values = line.rstrip().split(' ')[1:]
 					mode = line.split(' ')[0]
-					
-					if param_current=='OutputActivityRatio':    
+
+					if param_current=='OutputActivityRatio':
 						data_out.append(tuple([fuel,tech,mode]))
 						for i in range(0,len(years)):
 							output_table.append(tuple([tech,fuel,mode,years[i],values[i]]))
-					
+
 					if param_current=='InputActivityRatio':
-						data_inp.append(tuple([fuel,tech,mode]))   
-					
+						data_inp.append(tuple([fuel,tech,mode]))
+
 					data_all.append(tuple([tech,mode]))
 
 					if param_current == 'param TechnologyToStorage' or param_current == 'param TechnologyToStorage':
@@ -65,7 +65,7 @@ def main(data_infile, out_file):
 							for i in range(0,len(mode_list)):
 								if values[i] != '0':
 									storage_to.append(tuple([storage,tech,mode_list[i]]))
-					
+
 			if line.startswith(('param OutputActivityRatio','param InputActivityRatio','param TechnologyToStorage','param TechnologyFromStorage')):
 				param_current = line.split(' ')[1]
 				parsing = True
@@ -73,10 +73,17 @@ def main(data_infile, out_file):
 
 	list_RES = []
 	list_RES_outputs = []
+	list_RES_inputs = []
 	input_fuels = []
+	output_fuels = []
+
+	for each_out in data_out:
+		output_fuels.append(each_out[0])
 
 	for each_inp in data_inp:
 		input_fuels.append(each_inp[0])
+		if each_inp[0] not in output_fuels:
+			list_RES_inputs.append((each_inp[1],each_inp[0],each_inp[0]))
 
 	for each_out in data_out:
 		for each_inp in data_inp:
@@ -100,13 +107,14 @@ def main(data_infile, out_file):
 						list_RES_outputs.append(('LNDAGRXXX', each_out[0], each_out[0]))
 				else:
 					list_RES_outputs.append((each_out[1],each_out[0],each_out[0]))
-	
+
 	list_RES = list(set(list_RES))
 	list_RES_outputs = list(set(list_RES_outputs))
+	list_RES_inputs = list(set(list_RES_inputs))
 
 	f = Digraph('finite_state_machine', filename=out_file)
 	f.attr(rankdir='LR', size='8,5')
-	
+
 	for each in list_RES:
 		f.attr('node', shape='square')
 		f.edge(each[0], each[1], label=each[2])
@@ -115,7 +123,11 @@ def main(data_infile, out_file):
 		f.attr('node', shape='doublecircle')
 		f.edge(each[0], each[2], label=each[2])
 
-	f.view()
+	for each in list_RES_inputs:
+		f.attr('node', shape='doublecircle', fillcolor='red', style='filled')
+		f.edge(each[2], each[0], label=each[2])  
+
+	f.render()
 
 if __name__ == '__main__':
         data_infile = sys.argv[1]


### PR DESCRIPTION
The RES generator script previously filtered out connections where a commodity was an input to a technology but was not an output from any technology. These connections are now shown as filled red circles (to highlight that it will cause an error while running the model).